### PR TITLE
Ensure draws are processed chronologically

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python update_data.py --type super  # Update 威力彩 (superlotto638)
 the day after the last stored draw and `end` to today's date when querying
 `lot539.com`.
 
-The script uses `taiwan_lottery.py` to fetch draw results from [lot539.com](https://www.lot539.com), parse the draw period, date, numbers and special number, then append the results to the appropriate worksheets.
+The script uses `taiwan_lottery.py` to fetch draw results from [lot539.com](https://www.lot539.com), parse the draw period, date, numbers and special number, then append the results to the appropriate worksheets. Draws are sorted by period in ascending order before writing so that IDs and periods grow chronologically.
 
 Each time data is fetched, the new rows are also appended to local CSV files
 named `<type>_sequence.csv` and `<type>_sorted.csv` (where `<type>` is `big` or

--- a/update_data.py
+++ b/update_data.py
@@ -78,6 +78,8 @@ def main(lotto_type: str) -> None:
     end_date = datetime.today().strftime('%Y-%m-%d')
 
     draws = tl.get_latest_draws(lotto_type, start=start_date, end=end_date)
+    # Ensure chronological order so IDs and periods increase over time
+    draws.sort(key=lambda d: int(d.period))
 
     sequence_rows = []
     sorted_rows = []


### PR DESCRIPTION
## Summary
- keep lottery draws in ascending order before appending
- document that data is sorted chronologically

## Testing
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68424b9edbc4832fb06d7dfd5bad2cad