### PR TITLE
Fix Poetry install by removing missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-test-package = { path = "test-package" }
+
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- remove `test-package` from `pyproject.toml`
- add an empty `lotterypython` package so Poetry installs correctly

## Testing
- `poetry install`

------
https://chatgpt.com/codex/tasks/task_e_684250ec857c832f9bf1c38100e0c5b6