### PR TITLE
Fix prediction scripts to locate CSV files

### DIFF
--- a/predict/lotto_predict_LSTMRF.py
+++ b/predict/lotto_predict_LSTMRF.py
@@ -1,10 +1,11 @@
 import pandas as pd, numpy as np
+from pathlib import Path
 from collections import Counter
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from tensorflow.keras import layers, models
 
-CSV_FILE = "../power_lottery.csv"  
+CSV_FILE = Path(__file__).resolve().parents[1] / "power_lottery.csv"
 SEQ_LEN  = 10
 
 df = pd.read_csv(CSV_FILE)

--- a/predict/lotto_predict_lstm.py
+++ b/predict/lotto_predict_lstm.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from pathlib import Path
 from tensorflow.keras import layers, models
 
 """Simple LSTM-based predictor for lottery numbers.
@@ -10,7 +11,7 @@ numbers for the next draw. It uses only a small sequence of recent
 draws, so the results are for demonstration purposes only.
 """
 
-CSV_FILE = "../lotterypython/big_sequence.csv"
+CSV_FILE = Path(__file__).resolve().parents[1] / "lotterypython" / "big_sequence.csv"
 SEQ_LEN = 10
 
 


### PR DESCRIPTION
## Summary
- ensure LSTM prediction scripts resolve CSV paths relative to the repo
- add pathlib imports

## Testing
- `pip install pandas cloudscraper bs4 gspread oauth2client scikit-learn tensorflow --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685511a91488832f84a71e0bb0d6458d