### PR TITLE
Add option to save analysis results

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ string. Any leading `'` character from the original draw period is removed and
 the value is reformatted using `period[:3] + period[-3:]` before being
 appended.
 
+To save prediction results from the built-in analysis tools, omit
+`--update` and pass `--save-results`:
+
+```bash
+python -m lotterypython --type big --save-results
+```
+
+The results are appended to the `分析結果` worksheet of the same Google Sheet.
+
 ## LSTM Analysis
 
 An experimental script is provided to generate number predictions using an

--- a/lotterypython/analysis_sheet.py
+++ b/lotterypython/analysis_sheet.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import date
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+
+
+def append_analysis_results(predictions: list[tuple[str, list[int], int]], lotto_type: str) -> None:
+    """Append prediction rows to the "分析結果" worksheet.
+
+    Parameters
+    ----------
+    predictions:
+        A list of tuples ``(algorithm, numbers, special)``.
+    lotto_type:
+        Either ``"big"`` or ``"super"``.
+    """
+    scope = ["https://spreadsheets.google.com/feeds"]
+    creds = ServiceAccountCredentials.from_json_keyfile_name("credentials.json", scope)
+    client = gspread.authorize(creds)
+    book = client.open_by_key("1WApSh6XbBkcjAhDUyO8IvufhPHUX40MOIskl1qL89hQ")
+    try:
+        sheet = book.worksheet("分析結果")
+    except getattr(gspread, "WorksheetNotFound", Exception):
+        sheet = book.add_worksheet(title="分析結果", rows="100", cols="5")
+
+    today = date.today().isoformat()
+    rows = []
+    for algorithm, numbers, special in predictions:
+        num_str = " ".join(str(n) for n in numbers)
+        rows.append([today, lotto_type, algorithm, num_str, special])
+
+    if rows:
+        sheet.append_rows(rows)

--- a/tests/test_analysis_sheet.py
+++ b/tests/test_analysis_sheet.py
@@ -1,0 +1,42 @@
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from pathlib import Path
+import sys
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from lotterypython.analysis_sheet import append_analysis_results
+
+
+def test_append_analysis_results_formats_rows_and_appends():
+    preds = [
+        ("Algo1", [1, 2, 3, 4, 5, 6], 7),
+        ("Algo2", [11, 12, 13, 14, 15, 16], 8),
+    ]
+
+    with patch("lotterypython.analysis_sheet.gspread") as gs, patch(
+        "lotterypython.analysis_sheet.ServiceAccountCredentials"
+    ) as sac:
+        gs.WorksheetNotFound = Exception
+        client = MagicMock()
+        worksheet = MagicMock()
+        workbook = MagicMock()
+        client.open_by_key.return_value = workbook
+        workbook.worksheet.return_value = worksheet
+        gs.authorize.return_value = client
+        sac.from_json_keyfile_name.return_value = "creds"
+
+        append_analysis_results(preds, "big")
+
+        sac.from_json_keyfile_name.assert_called_once()
+        client.open_by_key.assert_called_once_with(
+            "1WApSh6XbBkcjAhDUyO8IvufhPHUX40MOIskl1qL89hQ"
+        )
+        workbook.worksheet.assert_called_once_with("分析結果")
+        today = date.today().isoformat()
+        expected = [
+            [today, "big", "Algo1", "1 2 3 4 5 6", 7],
+            [today, "big", "Algo2", "11 12 13 14 15 16", 8],
+        ]
+        worksheet.append_rows.assert_called_once_with(expected)


### PR DESCRIPTION
## Summary
- add helper to write predictions to Google Sheets
- support `--save-results` flag in legacy analysis
- document the new flag
- test `append_analysis_results` using mocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cfbe14a58832f9451c1e7629c80ca